### PR TITLE
Fixed that iframe would block mouse events

### DIFF
--- a/ResizeSensor.js
+++ b/ResizeSensor.js
@@ -15,6 +15,7 @@ var ResizeSensor = React.createClass({
         zIndex: -1,
         top: 0,
         left: 0,
+        pointerEvents: "none",
       }} />
     );
   },


### PR DESCRIPTION
Added a fix so that mouse events are ignored by iframe. This lets the user drag on any elements that are supposed to be interactable there. (such as when the iframe is in a scroll-view, and the scroll-view has background-drag enabled)